### PR TITLE
Bug fix for SecondaryNamenode startup failure

### DIFF
--- a/benchmarks/314.hadoop/hadoop.sh
+++ b/benchmarks/314.hadoop/hadoop.sh
@@ -36,19 +36,8 @@ if [ $? -ne 0 ]; then
 fi
 
 ############## get JAVA_HOME which need to be used later ################
-#[ "$(whereis java)"x != ""x ]
-#comment the discard code for reference
-if false; then
-    iRt1=1
-    IFS=:; for d1 in ${PATH}; do IFS=${g_IFS0};
-        s1=$(echo ${d1} | grep 'java' | grep 'bin' | grep -v 'jre')
-        if [ -n "${s1}" ]; then
-            java_loc=${s1%/bin}
-            iRt1=0
-            break
-        fi
-    IFS=$'\n'; done; IFS=${g_IFS0};
-fi
+
+
 #Is java installed?
 if ! hash java; then
     sudo apt-get -y install openjdk-7-jdk
@@ -75,7 +64,11 @@ pushd $HADOOP_DIR
     popd
 
 /usr/bin/expect  << EOF
+
+    set timeout  300
     spawn $HADOOP_SERVICE/stop-all.sh
+
+      
     expect {
         -re {connecting \(yes/no\)\?} {
             send "yes\n"
@@ -89,11 +82,13 @@ rm -fr $hdfs_tmp
 $HADOOP_BIN/hdfs namenode -format
 
 bOK1=false
-nMax1=5
+nMax1=2
 n1=0
 ##while for fixed the "SecondaryNameNode" not started.
 while [ ${n1} -lt ${nMax1} ]; do
     sInfo1=$(/usr/bin/expect  << EOF
+
+    set timeout  300
     spawn $HADOOP_SERVICE/start-dfs.sh
     expect {
         -re {connecting \(yes/no\)\?} {
@@ -127,6 +122,9 @@ if ! ${bOK1}; then
 fi
 
 /usr/bin/expect  << EOF
+
+   set timeout  300
+  
     spawn $HADOOP_SERVICE/start-yarn.sh
     expect {
         -re {connecting \(yes/no\)\?} {


### PR DESCRIPTION
Set the timeout  period for 300 sec in expect script  for hadoop daemons to start. This is repeated for 2 times to accommodate and compensate for any system delay