### PR TITLE
  Email feature is added to caliper.

### DIFF
--- a/caliper
+++ b/caliper
@@ -383,11 +383,48 @@ if __name__=="__main__":
         flag = generate_web_tar()
 
     if args.webpage and args.send_email:
-        flag = generate_web_tar()
-        result_path = os.path.join(caliper_path.folder_ope.results_dir,
+         flag = generate_web_tar()
+         result_path = os.path.join(caliper_path.folder_ope.results_dir,
                 'test_results.tar.gz')
-        if os.path.exists(result_path):
+         if os.path.exists(result_path):
             send_mails.send_mails(result_path)
+            print("\n'test_results.tar.gz file has been sent, please check the mail\n")
+            sys.exit()
+         if not os.path.exists(result_path):
+             try:
+                 os.makedirs(caliper_path.folder_ope.workspace)
+             except Exception as e:
+                 print("\nCan't able to send the mail as 'test_results.tar.gz' file is not created\n")
+                 sys.exit()
+
+
+    if args.folder and args.send_email:
+        result_path = os.path.join(caliper_path.folder_ope.workspace, caliper_path.folder_ope.name,
+                                   'results_summary.log')
+        if os.path.exists(result_path):
+             send_mails.send_mails(result_path)
+             print("\n'results_summary.log' file has been sent, please check the mail\n")
+             sys.exit()
+        if not os.path.exists(result_path):
+         try:
+            os.makedirs(caliper_path.folder_ope.workspace)
+         except Exception as e:
+            print("\nCan't able to send the mail as 'results_summary.log' file is not present\n ")
+            sys.exit()
+
+    if not args.folder and args.send_email:
+            result_path = os.path.join(caliper_path.folder_ope.workspace, caliper_path.folder_ope.name,
+                                   'results_summary.log')
+            if os.path.exists(result_path):
+                send_mails.send_mails(result_path)
+                print("\n'results_summary.log' file has been sent , please check the mail\n")
+                sys.exit()
+            if not os.path.exists(result_path):
+             try:
+                os.makedirs(caliper_path.folder_ope.workspace)
+             except Exception as e:
+              print("\n Can't able to send the mail as 'results_summary.log' file is not present\n ")
+             sys.exit()
 
     if not args.webpage and args.send_email:
         current_path = os.getcwd()

--- a/client/shared/send_mails.py
+++ b/client/shared/send_mails.py
@@ -6,6 +6,7 @@
 #    Desc      :
 
 import os
+import HTMLParser
 import smtplib
 from email.MIMEMultipart import MIMEMultipart
 from email.MIMEText import MIMEText
@@ -56,6 +57,7 @@ class EmailContext(object):
         msg['Subject'] = self.subject
         msg['From'] = self.fro
         msg['To'] = ','.join(self.to)
+        msg['plaintext'] = self.plaintext
         msg.preamble = 'This is a multi-part message in MIME format'
         msgAlternative = MIMEMultipart('alternative')
         msg.attach(msgAlternative)
@@ -90,6 +92,8 @@ class EmailSender(object):
         # set the debug level
         # smtp.set_debuglevel(1)
         smtp.connect(auth.server)
+        smtp.starttls()
+        smtp.ehlo()
         smtp.login(auth.user, auth.password)
         smtp.sendmail(email.fro, email.to, email.getContext())
         smtp.quit()


### PR DESCRIPTION
 	 Caliper will send emails to pre-configured mail addresses with building and execution results and web-report
	 The neccessary configurations should be configured in 'email_config.cfg' file.
	 The '-e' option should be added for sending mails.
	 Example: caliper -brpse , caliper -BRPSwe